### PR TITLE
修改网络连通性检查站

### DIFF
--- a/src/main/kotlin/com/rsplwe/esurfing/Constants.kt
+++ b/src/main/kotlin/com/rsplwe/esurfing/Constants.kt
@@ -9,6 +9,6 @@ object Constants {
     const val REQUEST_ACCEPT = "text/html,text/xml,application/xhtml+xml,application/x-javascript,*/*"
     const val BASE_URL = "http://14.146.227.141:7001"
     const val PORTAL_NODE = "http://61.140.12.23:10002"
-    const val CAPTIVE_URL = "http://www.gstatic.com/generate_204"
+    const val CAPTIVE_URL = "http://connect.rom.miui.com/generate_204"
     const val AUTH_URL = "$BASE_URL/auth.cgi"
 }


### PR DESCRIPTION
https://github.com/Rsplwe/ESurfingDialer/issues/27
其实这个问题我之前也发现过，在没有认证的情况下甚至www.gstatic.com无法302到enet.10000.gd.cn，但connect.rom.miui.com不会，这个在我们学校会有
无法跳转是其次，主要是还会造成程序假死
所以就特意挑了个比较好的检查站并进行修改